### PR TITLE
Feature parsing regular URL's

### DIFF
--- a/Pod/Tests/TestCompass.swift
+++ b/Pod/Tests/TestCompass.swift
@@ -5,7 +5,7 @@ class TestCompass: XCTestCase {
 
   override func setUp() {
     Compass.scheme = "compassTests"
-    Compass.routes = ["profile:{user}", "login"]
+    Compass.routes = ["profile:{user}", "login", "callback"]
   }
 
   func testScheme() {
@@ -14,7 +14,7 @@ class TestCompass: XCTestCase {
 
   func testRoutes() {
     XCTAssert(!Compass.routes.isEmpty)
-    XCTAssert(Compass.routes.count == 2)
+    XCTAssert(Compass.routes.count == 3)
     XCTAssertEqual(Compass.routes[0], "profile:{user}")
     XCTAssertEqual(Compass.routes[1], "login")
   }
@@ -36,10 +36,32 @@ class TestCompass: XCTestCase {
   }
 
   func testParseWithoutArguments() {
-    let url = NSURL(string: "compassTest://login")!
+    let url = NSURL(string: "compassTests://login")!
     Compass.parse(url) { route, arguments in
       XCTAssertEqual("login", route)
       XCTAssert(arguments.isEmpty)
+    }
+  }
+
+  func testParseRegularURLWithFragments() {
+    let url = NSURL(string: "compassTests://callback/#access_token=IjvcgrkQk1p7TyJxKa26rzM1wBMFZW6XoHK4t5Gkt1xQLTN8l7ppR0H3EZXpoP0uLAN49oCDqTHsvnEV&token_type=Bearer&expires_in=3600")!
+    Compass.parse(url) { route, arguments in
+      XCTAssertEqual(route, "callback")
+      XCTAssertEqual(arguments.count, 3)
+      XCTAssertEqual(arguments["access_token"], "IjvcgrkQk1p7TyJxKa26rzM1wBMFZW6XoHK4t5Gkt1xQLTN8l7ppR0H3EZXpoP0uLAN49oCDqTHsvnEV")
+      XCTAssertEqual(arguments["expires_in"], "3600")
+      XCTAssertEqual(arguments["token_type"], "Bearer")
+    }
+  }
+
+  func testParseRegularURLWithQuery() {
+    let url = NSURL(string: "compassTests://callback/?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
+    Compass.parse(url) { route, arguments in
+      XCTAssertEqual(route, "callback")
+      XCTAssertEqual(arguments.count, 3)
+      XCTAssertEqual(arguments["access_token"], "Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l")
+      XCTAssertEqual(arguments["expires_in"], "3600")
+      XCTAssertEqual(arguments["token_type"], "Bearer")
     }
   }
 }

--- a/Source/Compass.swift
+++ b/Source/Compass.swift
@@ -17,6 +17,8 @@ public struct Compass {
     var result = false
     let query = url.absoluteString.substringFromIndex(scheme.endIndex)
 
+    guard !query.containsString("/") else { return parseAsURL(url, completion: completion) }
+
     for route in routes.sort({ $0 < $1 }) {
       guard let prefix = (route.characters
         .split { $0 == "{" }
@@ -25,8 +27,8 @@ public struct Compass {
 
       if query.hasPrefix(prefix) || prefix.hasPrefix(query) {
         let queryString = query.stringByReplacingOccurrencesOfString(prefix, withString: "")
-        let queryArguments = paths(queryString)
-        let routeArguments = paths(route).filter { $0.containsString("{") }
+        let queryArguments = splitString(queryString, delimiter: ":")
+        let routeArguments = splitString(route, delimiter: ":").filter { $0.containsString("{") }
 
         var arguments = [String : String]()
 
@@ -46,6 +48,23 @@ public struct Compass {
     return result
   }
 
+  static func parseAsURL(url: NSURL, completion: ParseCompletion) -> Bool {
+    guard let route = url.host else { return false }
+
+    var arguments = [String : String]()
+
+    [url.fragment, url.query].forEach {
+      splitString($0, delimiter: "&").forEach {
+        let pair = splitString($0, delimiter: "=")
+        arguments[pair[0]] = pair[1]
+      }
+    }
+
+    completion(route: route, arguments: arguments)
+
+    return true
+  }
+
   public static func navigate(urn: String, scheme: String = Compass.scheme) {
     let stringURL = "\(scheme)\(urn)"
     guard let url = NSURL(string: stringURL) else { return }
@@ -55,9 +74,11 @@ public struct Compass {
 
   // MARK: - Private Helpers
 
-  private static func paths(urn: String) -> [String] {
-    return urn.characters
-      .split { $0 == ":" }
+  private static func splitString(string: String?, delimiter: Character) -> [String] {
+    guard let string = string else { return [] }
+
+    return string.characters
+      .split { $0 == delimiter }
       .map(String.init)
   }
 }


### PR DESCRIPTION
With this PR, Compass can handle regular URL's with both queries and/or fragments.

So when parsing the this example;

`compassTests://callback/#access_token=IjvcgrkQk1p7TyJxKa26rzM1wBMFZW6XoHK4t5Gkt1xQLTN8l7ppR0H3EZXpoP0uLAN49oCDqTHsvnEV&token_type=Bearer&expires_in=3600`

Route in the callback would end up being `callback` and all of the fragments would be stored for you in `arguments` as a key value pair. Same thing would happen if you used a URL with a query instead of fragments.
