### PR TITLE
Fix URN parsing

### DIFF
--- a/Source/Compass.swift
+++ b/Source/Compass.swift
@@ -26,7 +26,7 @@ public struct Compass {
         .map(String.init))
         .first else { continue }
 
-      if query.hasPrefix(prefix) && prefix.hasPrefix(query) {
+      if query.hasPrefix(prefix) || prefix.hasPrefix(query) {
         let queryString = query.stringByReplacingOccurrencesOfString(prefix, withString: "")
         let queryArguments = splitString(queryString, delimiter: ":")
         let routeArguments = splitString(route, delimiter: ":").filter { $0.containsString("{") }

--- a/Source/Compass.swift
+++ b/Source/Compass.swift
@@ -17,7 +17,7 @@ public struct Compass {
     var result = false
     let query = url.absoluteString.substringFromIndex(scheme.endIndex)
 
-    guard !query.containsString("/?") || !query.containsString("/#")
+    guard !(query.containsString("/?") || query.containsString("/#"))
       else { return parseAsURL(url, completion: completion) }
 
     for route in routes.sort({ $0 < $1 }) {

--- a/Tests/TestCompass.swift
+++ b/Tests/TestCompass.swift
@@ -6,7 +6,7 @@ class TestCompass: XCTestCase {
 
   override func setUp() {
     Compass.scheme = "compassTests"
-    Compass.routes = ["profile:{user}", "login", "callback"]
+    Compass.routes = ["profile:{user}", "login", "callback", "user:list:{userId}:{kind}"]
   }
 
   func testScheme() {
@@ -15,7 +15,7 @@ class TestCompass: XCTestCase {
 
   func testRoutes() {
     XCTAssert(!Compass.routes.isEmpty)
-    XCTAssert(Compass.routes.count == 3)
+    XCTAssert(Compass.routes.count == 4)
     XCTAssertEqual(Compass.routes[0], "profile:{user}")
     XCTAssertEqual(Compass.routes[1], "login")
   }

--- a/Tests/TestCompass.swift
+++ b/Tests/TestCompass.swift
@@ -107,5 +107,7 @@ class TestCompass: XCTestCase {
 
       expectation.fulfill()
     }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
   }
 }

--- a/Tests/TestCompass.swift
+++ b/Tests/TestCompass.swift
@@ -26,8 +26,8 @@ class TestCompass: XCTestCase {
 
     Compass.parse(url) { route, arguments in
       XCTAssertEqual("profile:{user}", route)
-      XCTAssertEqual(arguments["user"], "testUdssser")
-      
+      XCTAssertEqual(arguments["user"], "testUser")
+
       expectation.fulfill()
     }
 

--- a/Tests/TestCompass.swift
+++ b/Tests/TestCompass.swift
@@ -21,48 +21,91 @@ class TestCompass: XCTestCase {
   }
 
   func testParseArguments() {
+    let expectation = self.expectationWithDescription("Parse arguments")
     let url = NSURL(string: "compassTests://profile:testUser")!
+
     Compass.parse(url) { route, arguments in
       XCTAssertEqual("profile:{user}", route)
-      XCTAssertEqual(arguments["user"], "testUser")
+      XCTAssertEqual(arguments["user"], "testUdssser")
+      
+      expectation.fulfill()
     }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
+  }
+
+  func testParseMultipleArguments() {
+    let expectation = self.expectationWithDescription("Parse multiple arguments")
+    let url = NSURL(string: "compassTests://user:list:1:admin")!
+
+    Compass.parse(url) { route, arguments in
+      XCTAssertEqual("user:list:{userId}:{kind}", route)
+      XCTAssertEqual(arguments["userId"], "1")
+      XCTAssertEqual(arguments["kind"], "admin")
+
+      expectation.fulfill()
+    }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
   }
 
   func testParseOptionalArguments() {
+    let expectation = self.expectationWithDescription("Parse optional arguments")
     let url = NSURL(string: "compassTests://profile")!
+
     Compass.parse(url) { route, arguments in
       XCTAssertEqual("profile:{user}", route)
       XCTAssert(arguments.isEmpty)
+
+      expectation.fulfill()
     }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
   }
 
   func testParseWithoutArguments() {
+    let expectation = self.expectationWithDescription("Parse without arguments")
     let url = NSURL(string: "compassTests://login")!
+
     Compass.parse(url) { route, arguments in
       XCTAssertEqual("login", route)
       XCTAssert(arguments.isEmpty)
+
+      expectation.fulfill()
     }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
   }
 
   func testParseRegularURLWithFragments() {
+    let expectation = self.expectationWithDescription("Parse URL with fragments")
     let url = NSURL(string: "compassTests://callback/#access_token=IjvcgrkQk1p7TyJxKa26rzM1wBMFZW6XoHK4t5Gkt1xQLTN8l7ppR0H3EZXpoP0uLAN49oCDqTHsvnEV&token_type=Bearer&expires_in=3600")!
+
     Compass.parse(url) { route, arguments in
       XCTAssertEqual(route, "callback")
       XCTAssertEqual(arguments.count, 3)
       XCTAssertEqual(arguments["access_token"], "IjvcgrkQk1p7TyJxKa26rzM1wBMFZW6XoHK4t5Gkt1xQLTN8l7ppR0H3EZXpoP0uLAN49oCDqTHsvnEV")
       XCTAssertEqual(arguments["expires_in"], "3600")
       XCTAssertEqual(arguments["token_type"], "Bearer")
+
+      expectation.fulfill()
     }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
   }
 
   func testParseRegularURLWithQuery() {
+    let expectation = self.expectationWithDescription("Parse URL with query")
     let url = NSURL(string: "compassTests://callback/?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
+
     Compass.parse(url) { route, arguments in
       XCTAssertEqual(route, "callback")
       XCTAssertEqual(arguments.count, 3)
       XCTAssertEqual(arguments["access_token"], "Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l")
       XCTAssertEqual(arguments["expires_in"], "3600")
       XCTAssertEqual(arguments["token_type"], "Bearer")
+
+      expectation.fulfill()
     }
   }
 }


### PR DESCRIPTION
@zenangst 
1. Add expectations to tests, they didn't work properly because we have closures, so we didn't see some of them actually weren't passing.
2.  Back to the condition we had before https://github.com/hyperoslo/Compass/pull/20, `prefix` couldn't have `query` as a prefix, because `prefix` is a part of the `route`, so it's a part of the `query` as well.
3. Fix `guard` condition for URL parsing.
