### PR TITLE
Feature: URL with no slash

### DIFF
--- a/Source/Compass.swift
+++ b/Source/Compass.swift
@@ -17,7 +17,7 @@ public struct Compass {
     var result = false
     let query = url.absoluteString.substringFromIndex(scheme.endIndex)
 
-    guard !(query.containsString("/?") || query.containsString("/#"))
+    guard !(query.containsString("?") || query.containsString("#"))
       else { return parseAsURL(url, completion: completion) }
 
     for route in routes.sort({ $0 < $1 }) {

--- a/Tests/TestCompass.swift
+++ b/Tests/TestCompass.swift
@@ -94,9 +94,26 @@ class TestCompass: XCTestCase {
     self.waitForExpectationsWithTimeout(4.0, handler:nil)
   }
 
+  func testParseRegularURLWithSlashQuery() {
+    let expectation = self.expectationWithDescription("Parse URL with slash query")
+    let url = NSURL(string: "compassTests://callback/?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
+
+    Compass.parse(url) { route, arguments in
+      XCTAssertEqual(route, "callback")
+      XCTAssertEqual(arguments.count, 3)
+      XCTAssertEqual(arguments["access_token"], "Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l")
+      XCTAssertEqual(arguments["expires_in"], "3600")
+      XCTAssertEqual(arguments["token_type"], "Bearer")
+
+      expectation.fulfill()
+    }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
+  }
+
   func testParseRegularURLWithQuery() {
     let expectation = self.expectationWithDescription("Parse URL with query")
-    let url = NSURL(string: "compassTests://callback/?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
+    let url = NSURL(string: "compassTests://callback?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
 
     Compass.parse(url) { route, arguments in
       XCTAssertEqual(route, "callback")


### PR DESCRIPTION
@zenangst 
I think we should support the case when there is no slash before `?` or `#`, like `compassTests://callback?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600`
