### PR TITLE
Feature: conventional routers & routes

### DIFF
--- a/Compass.xcodeproj/project.pbxproj
+++ b/Compass.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		BDF7B4171C3FF51800576737 /* Sugar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDF7B4161C3FF51800576737 /* Sugar.framework */; };
 		D5A2A7931C4CEB1C00B51356 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7921C4CEB1C00B51356 /* Routable.swift */; };
 		D5A2A7941C4CEB1C00B51356 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7921C4CEB1C00B51356 /* Routable.swift */; };
+		D5A2A7971C4CEB7C00B51356 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7961C4CEB7C00B51356 /* Router.swift */; };
+		D5A2A7981C4CEB7C00B51356 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7961C4CEB7C00B51356 /* Router.swift */; };
+		D5A2A79A1C4CEDDA00B51356 /* TestRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7991C4CEDDA00B51356 /* TestRouter.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Compass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Compass.framework */; };
 		D5C6294A1C3A7FAA007F7B7C /* Compass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Compass.framework */; };
 /* End PBXBuildFile section */
@@ -46,6 +49,8 @@
 		BDF7B4141C3FF51100576737 /* Sugar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sugar.framework; path = Carthage/Build/Mac/Sugar.framework; sourceTree = "<group>"; };
 		BDF7B4161C3FF51800576737 /* Sugar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sugar.framework; path = Carthage/Build/iOS/Sugar.framework; sourceTree = "<group>"; };
 		D5A2A7921C4CEB1C00B51356 /* Routable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
+		D5A2A7961C4CEB7C00B51356 /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		D5A2A7991C4CEDDA00B51356 /* TestRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestRouter.swift; path = Sources/iOS/TestRouter.swift; sourceTree = SOURCE_ROOT; };
 		D5B2E89F1C3A780C00C0327D /* Compass.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Compass.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B2E8A91C3A780C00C0327D /* Compass-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Compass-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C629401C3A7FAA007F7B7C /* Compass.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Compass.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -139,6 +144,7 @@
 			children = (
 				D5A2A7921C4CEB1C00B51356 /* Routable.swift */,
 				BDF7B40D1C3FF41500576737 /* Compass+Navigate.swift */,
+				D5A2A7961C4CEB7C00B51356 /* Router.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -174,6 +180,7 @@
 		D5C629921C3A8BDA007F7B7C /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				D5A2A7991C4CEDDA00B51356 /* TestRouter.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -400,6 +407,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5A2A7971C4CEB7C00B51356 /* Router.swift in Sources */,
 				BDF7B4091C3FF40300576737 /* Compass.swift in Sources */,
 				D5A2A7931C4CEB1C00B51356 /* Routable.swift in Sources */,
 				BDF7B40E1C3FF41500576737 /* Compass+Navigate.swift in Sources */,
@@ -410,6 +418,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5A2A79A1C4CEDDA00B51356 /* TestRouter.swift in Sources */,
 				BDF7B4101C3FF43F00576737 /* TestCompass.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -418,6 +427,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5A2A7981C4CEB7C00B51356 /* Router.swift in Sources */,
 				BDF7B40A1C3FF40300576737 /* Compass.swift in Sources */,
 				D5A2A7941C4CEB1C00B51356 /* Routable.swift in Sources */,
 				BDF7B40C1C3FF40A00576737 /* Compass+Navigate.swift in Sources */,

--- a/Compass.xcodeproj/project.pbxproj
+++ b/Compass.xcodeproj/project.pbxproj
@@ -16,9 +16,7 @@
 		BDF7B4151C3FF51100576737 /* Sugar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDF7B4141C3FF51100576737 /* Sugar.framework */; };
 		BDF7B4171C3FF51800576737 /* Sugar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDF7B4161C3FF51800576737 /* Sugar.framework */; };
 		D5A2A7931C4CEB1C00B51356 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7921C4CEB1C00B51356 /* Routable.swift */; };
-		D5A2A7941C4CEB1C00B51356 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7921C4CEB1C00B51356 /* Routable.swift */; };
 		D5A2A7971C4CEB7C00B51356 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7961C4CEB7C00B51356 /* Router.swift */; };
-		D5A2A7981C4CEB7C00B51356 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7961C4CEB7C00B51356 /* Router.swift */; };
 		D5A2A79A1C4CEDDA00B51356 /* TestRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7991C4CEDDA00B51356 /* TestRouter.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Compass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Compass.framework */; };
 		D5C6294A1C3A7FAA007F7B7C /* Compass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Compass.framework */; };
@@ -427,9 +425,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5A2A7981C4CEB7C00B51356 /* Router.swift in Sources */,
 				BDF7B40A1C3FF40300576737 /* Compass.swift in Sources */,
-				D5A2A7941C4CEB1C00B51356 /* Routable.swift in Sources */,
 				BDF7B40C1C3FF40A00576737 /* Compass+Navigate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Compass.xcodeproj/project.pbxproj
+++ b/Compass.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		BDF7B4111C3FF43F00576737 /* TestCompass.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF7B40F1C3FF43F00576737 /* TestCompass.swift */; };
 		BDF7B4151C3FF51100576737 /* Sugar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDF7B4141C3FF51100576737 /* Sugar.framework */; };
 		BDF7B4171C3FF51800576737 /* Sugar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDF7B4161C3FF51800576737 /* Sugar.framework */; };
+		D5A2A7931C4CEB1C00B51356 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7921C4CEB1C00B51356 /* Routable.swift */; };
+		D5A2A7941C4CEB1C00B51356 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7921C4CEB1C00B51356 /* Routable.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Compass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Compass.framework */; };
 		D5C6294A1C3A7FAA007F7B7C /* Compass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Compass.framework */; };
 /* End PBXBuildFile section */
@@ -43,6 +45,7 @@
 		BDF7B40F1C3FF43F00576737 /* TestCompass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCompass.swift; sourceTree = "<group>"; };
 		BDF7B4141C3FF51100576737 /* Sugar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sugar.framework; path = Carthage/Build/Mac/Sugar.framework; sourceTree = "<group>"; };
 		BDF7B4161C3FF51800576737 /* Sugar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sugar.framework; path = Carthage/Build/iOS/Sugar.framework; sourceTree = "<group>"; };
+		D5A2A7921C4CEB1C00B51356 /* Routable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Compass.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Compass.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B2E8A91C3A780C00C0327D /* Compass-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Compass-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C629401C3A7FAA007F7B7C /* Compass.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Compass.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -134,6 +137,7 @@
 		D5C6296A1C3A809D007F7B7C /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				D5A2A7921C4CEB1C00B51356 /* Routable.swift */,
 				BDF7B40D1C3FF41500576737 /* Compass+Navigate.swift */,
 			);
 			path = iOS;
@@ -397,6 +401,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDF7B4091C3FF40300576737 /* Compass.swift in Sources */,
+				D5A2A7931C4CEB1C00B51356 /* Routable.swift in Sources */,
 				BDF7B40E1C3FF41500576737 /* Compass+Navigate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -414,6 +419,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDF7B40A1C3FF40300576737 /* Compass.swift in Sources */,
+				D5A2A7941C4CEB1C00B51356 /* Routable.swift in Sources */,
 				BDF7B40C1C3FF40A00576737 /* Compass+Navigate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ route handling code and avoid huge `switch` cases.
 in one place:
 ```swift
 struct ProfileRoute: Routable {
-  func resolve(arguments: [String: String], navigationController: UINavigationController) {
+  func resolve(arguments: [String: String], navigationController: UINavigationController?) {
     guard let username = arguments["username"] else { return }
 
     let profileController = profileController(title: username)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ struct ProfileRoute: Routable {
 let router = Router()
 router.routes = [
   "profile:{username}" : ProfileRoute(),
-  // "login:{username}" : LoginRoute()
+  // "logout" : LogoutRoute()
 ]
 ```
 

--- a/Sources/iOS/Routable.swift
+++ b/Sources/iOS/Routable.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+public protocol Routable {
+
+  func resolve(arguments: [String: String], navigationController: UINavigationController)
+}

--- a/Sources/iOS/Routable.swift
+++ b/Sources/iOS/Routable.swift
@@ -2,5 +2,5 @@ import UIKit
 
 public protocol Routable {
 
-  func resolve(arguments: [String: String], navigationController: UINavigationController)
+  func resolve(arguments: [String: String], navigationController: UINavigationController?)
 }

--- a/Sources/iOS/Router.swift
+++ b/Sources/iOS/Router.swift
@@ -6,7 +6,7 @@ public struct Router {
 
   public init() {}
 
-  public func navigate(route: String, arguments: [String: String], navigationController: UINavigationController) {
+  public func navigate(route: String, arguments: [String: String], navigationController: UINavigationController?) {
     guard let route = routes[route] else { return }
 
     route.resolve(arguments, navigationController: navigationController)

--- a/Sources/iOS/Router.swift
+++ b/Sources/iOS/Router.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+public struct Router {
+
+  public var routes = [String: Routable]()
+
+  public init() {}
+
+  public func navigate(route: String, arguments: [String: String], navigationController: UINavigationController) {
+    guard let route = routes[route] else { return }
+
+    route.resolve(arguments, navigationController: navigationController)
+  }
+}

--- a/Sources/iOS/TestRouter.swift
+++ b/Sources/iOS/TestRouter.swift
@@ -1,9 +1,37 @@
-//
-//  TestRouter.swift
-//  Compass
-//
-//  Created by Vadym Markov on 18/01/16.
-//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
-//
-
 import Foundation
+import XCTest
+import Compass
+
+class TestRoute: Routable {
+
+  var resolved = false
+
+  func resolve(arguments: [String: String], navigationController: UINavigationController) {
+    resolved = true
+  }
+}
+
+class TestRouter: XCTestCase {
+
+  var router: Router!
+  var navigationController = UINavigationController()
+  var route: TestRoute!
+
+  override func setUp() {
+    router = Router()
+    route = TestRoute()
+  }
+
+  func testNavigateIfRouteRegistered() {
+    router.routes["test"] = route
+    router.navigate("test", arguments: [:], navigationController: navigationController)
+
+    XCTAssertTrue(route.resolved)
+  }
+
+  func testNavigateIfRouteNotRegistered() {
+    router.navigate("test", arguments: [:], navigationController: navigationController)
+
+    XCTAssertFalse(route.resolved)
+  }
+}

--- a/Sources/iOS/TestRouter.swift
+++ b/Sources/iOS/TestRouter.swift
@@ -6,7 +6,7 @@ class TestRoute: Routable {
 
   var resolved = false
 
-  func resolve(arguments: [String: String], navigationController: UINavigationController) {
+  func resolve(arguments: [String: String], navigationController: UINavigationController?) {
     resolved = true
   }
 }

--- a/Sources/iOS/TestRouter.swift
+++ b/Sources/iOS/TestRouter.swift
@@ -1,0 +1,9 @@
+//
+//  TestRouter.swift
+//  Compass
+//
+//  Created by Vadym Markov on 18/01/16.
+//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
@zenangst 
There are some conventional tools that could be used to organise your route handling code and avoid huge `switch` cases.
- Implement `Routable` protocol to keep your single route navigation code in one place:

``` swift
struct ProfileRoute: Routable {
  func resolve(arguments: [String: String], navigationController: UINavigationController?) {
    guard let username = arguments["username"] else { return }

    let profileController = profileController(title: username)
    navigationController?.pushViewController(profileController, animated: true)
  }
}
```
- Create a `Router` instance and register your routes:

``` swift
let router = Router()
router.routes = [
  "profile:{username}" : ProfileRoute(),
  // "logout" : LogoutRoute()
]
```
- Parse URL with **Compass** and navigate to the route with a help of your `Router` instance.

``` swift
func application(app: UIApplication,
  openURL url: NSURL,
  options: [String : AnyObject]) -> Bool {
    return Compass.parse(url) { route, arguments in
      router.navigate(route, arguments: arguments,
        navigationController: navigationController)
    }
}
```
