### PR TITLE
Improve/routable

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "hyperoslo/Sugar" "1.0.3"
+github "hyperoslo/Sugar" "1.1.1"

--- a/CompassTests/iOS/TestRouter.swift
+++ b/CompassTests/iOS/TestRouter.swift
@@ -6,7 +6,7 @@ class TestRoute: Routable {
 
   var resolved = false
 
-  func resolve(arguments: [String: String], navigationController: UINavigationController?) {
+  func resolve(arguments: [String: String], currentController controller: UIViewController) {
     resolved = true
   }
 }
@@ -14,7 +14,7 @@ class TestRoute: Routable {
 class TestRouter: XCTestCase {
 
   var router: Router!
-  var navigationController = UINavigationController()
+  var controller = UIViewController()
   var route: TestRoute!
 
   override func setUp() {
@@ -24,13 +24,13 @@ class TestRouter: XCTestCase {
 
   func testNavigateIfRouteRegistered() {
     router.routes["test"] = route
-    router.navigate("test", arguments: [:], navigationController: navigationController)
+    router.navigate("test", arguments: [:], from: controller)
 
     XCTAssertTrue(route.resolved)
   }
 
   func testNavigateIfRouteNotRegistered() {
-    router.navigate("test", arguments: [:], navigationController: navigationController)
+    router.navigate("test", arguments: [:], from: controller)
 
     XCTAssertFalse(route.resolved)
   }

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ route handling code and avoid huge `switch` cases.
 in one place:
 ```swift
 struct ProfileRoute: Routable {
-  func resolve(arguments: [String: String], navigationController: UINavigationController?) {
+  func resolve(arguments: [String: String], currentController: UIViewController?) {
     guard let username = arguments["username"] else { return }
 
     let profileController = profileController(title: username)
-    navigationController?.pushViewController(profileController, animated: true)
+    currentController.navigationController?.pushViewController(profileController, animated: true)
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ route handling code and avoid huge `switch` cases.
 in one place:
 ```swift
 struct ProfileRoute: Routable {
-  func resolve(arguments: [String: String], currentController: UIViewController?) {
+  func resolve(arguments: [String: String], currentController: UIViewController) {
     guard let username = arguments["username"] else { return }
 
     let profileController = profileController(title: username)

--- a/Sources/iOS/Routable.swift
+++ b/Sources/iOS/Routable.swift
@@ -2,5 +2,5 @@ import UIKit
 
 public protocol Routable {
 
-  func resolve(arguments: [String: String], navigationController: UINavigationController?)
+  func resolve(arguments: [String: String], currentController: UIViewController)
 }

--- a/Sources/iOS/Router.swift
+++ b/Sources/iOS/Router.swift
@@ -6,9 +6,9 @@ public struct Router {
 
   public init() {}
 
-  public func navigate(route: String, arguments: [String: String], navigationController: UINavigationController?) {
+  public func navigate(route: String, arguments: [String: String], from controller: UIViewController) {
     guard let route = routes[route] else { return }
 
-    route.resolve(arguments, navigationController: navigationController)
+    route.resolve(arguments, currentController: controller)
   }
 }


### PR DESCRIPTION
**_Breaking change**_

It makes more sense to have current `UIViewController` instead of `UINavigationController` in `Routable`, because you always can get navigation controller from it: `currentController.navigationController`. It also means you can present on top of already presented controller which doesn't have navigation controller.
