### PR TITLE
Improve parsing

### DIFF
--- a/CompassTests/Shared/TestCompass.swift
+++ b/CompassTests/Shared/TestCompass.swift
@@ -6,7 +6,7 @@ class TestCompass: XCTestCase {
 
   override func setUp() {
     Compass.scheme = "compassTests"
-    Compass.routes = ["profile:{user}", "login", "callback", "user:list:{userId}:{kind}"]
+    Compass.routes = ["profile:{user}", "login", "callback", "user:list:{userId}:{kind}", "{appId}:user:list:{userId}:{kind}"]
   }
 
   func testScheme() {
@@ -15,7 +15,7 @@ class TestCompass: XCTestCase {
 
   func testRoutes() {
     XCTAssert(!Compass.routes.isEmpty)
-    XCTAssert(Compass.routes.count == 4)
+    XCTAssert(Compass.routes.count == 5)
     XCTAssertEqual(Compass.routes[0], "profile:{user}")
     XCTAssertEqual(Compass.routes[1], "login")
   }
@@ -55,6 +55,22 @@ class TestCompass: XCTestCase {
 
     Compass.parse(url) { route, arguments, _ in
       XCTAssertEqual("user:list:{userId}:{kind}", route)
+      XCTAssertEqual(arguments["userId"], "1")
+      XCTAssertEqual(arguments["kind"], "admin")
+
+      expectation.fulfill()
+    }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
+  }
+
+  func testParseMultipleArgumentsWithFirstWildcard() {
+    let expectation = self.expectationWithDescription("Parse multiple arguments with first wild card")
+    let url = NSURL(string: "compassTests://12:user:list:1:admin")!
+
+    Compass.parse(url) { route, arguments, _ in
+      XCTAssertEqual("{appId}:user:list:{userId}:{kind}", route)
+      XCTAssertEqual(arguments["appId"], "12")
       XCTAssertEqual(arguments["userId"], "1")
       XCTAssertEqual(arguments["kind"], "admin")
 

--- a/Sources/Shared/Compass.swift
+++ b/Sources/Shared/Compass.swift
@@ -5,6 +5,8 @@ public struct Compass {
 
   private static var internalScheme = ""
 
+  public static var delimiter: String = ":"
+
   public static var scheme: String {
     set { Compass.internalScheme = newValue }
     get { return "\(Compass.internalScheme)://" }
@@ -51,8 +53,8 @@ public struct Compass {
   }
 
   static func findMatch(routeString: String, pathString: String) -> (route: String, arguments: [String: String])? {
-    let routes = routeString.split(":")
-    let paths = pathString.split(":")
+    let routes = routeString.split(delimiter)
+    let paths = pathString.split(delimiter)
 
     var arguments: [String: String] = [:]
 


### PR DESCRIPTION
- This compares routes and paths step by step in pair, using `zip`
- Allow wildcard to be at the first of the route string, like

```
{appId}:user:list:{userId}:{kind}
```
- In case of multiple matches, the first is returned
