### PR TITLE
Add matchCount to find the route with the most matches

### DIFF
--- a/CompassTests/Shared/TestCompass.swift
+++ b/CompassTests/Shared/TestCompass.swift
@@ -6,7 +6,14 @@ class TestCompass: XCTestCase {
 
   override func setUp() {
     Compass.scheme = "compassTests"
-    Compass.routes = ["profile:{user}", "login", "callback", "user:list:{userId}:{kind}", "{appId}:user:list:{userId}:{kind}"]
+    Compass.routes = [
+      "profile:{user}",
+      "login",
+      "callback",
+      "user:list",
+      "user:list:{userId}:{kind}",
+      "{appId}:user:list:{userId}:{kind}"
+    ]
   }
 
   func testScheme() {
@@ -15,7 +22,7 @@ class TestCompass: XCTestCase {
 
   func testRoutes() {
     XCTAssert(!Compass.routes.isEmpty)
-    XCTAssert(Compass.routes.count == 5)
+    XCTAssert(Compass.routes.count == 6)
     XCTAssertEqual(Compass.routes[0], "profile:{user}")
     XCTAssertEqual(Compass.routes[1], "login")
   }
@@ -42,6 +49,20 @@ class TestCompass: XCTestCase {
       XCTAssertEqual("profile:{user}", route)
       XCTAssertEqual(arguments["user"], "testUser")
       XCTAssertEqual("foo" , fragments["meta"] as? String)
+
+      expectation.fulfill()
+    }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
+  }
+
+  func testParseRouteSamePrefix() {
+    let expectation = self.expectationWithDescription("Parse route having same prefix")
+    let url = NSURL(string: "compassTests://user:list")!
+
+    Compass.parse(url) { route, arguments, _ in
+      XCTAssertEqual("user:list", route)
+      XCTAssert(arguments.isEmpty)
 
       expectation.fulfill()
     }

--- a/Sources/Shared/Compass.swift
+++ b/Sources/Shared/Compass.swift
@@ -25,6 +25,8 @@ public struct Compass {
 
     let results = routes.flatMap {
       return findMatch($0, pathString: path)
+    }.sort {
+      return $0.matchCount > $1.matchCount
     }
 
     if let result = results.first {
@@ -52,26 +54,33 @@ public struct Compass {
     return true
   }
 
-  static func findMatch(routeString: String, pathString: String) -> (route: String, arguments: [String: String])? {
+  static func findMatch(routeString: String, pathString: String)
+    -> (route: String, arguments: [String: String], matchCount: Int)? {
+
     let routes = routeString.split(delimiter)
     let paths = pathString.split(delimiter)
 
     var arguments: [String: String] = [:]
+
+    var matchCount = 0
 
     for (route, path) in zip(routes, paths) {
       if route.hasPrefix("{") {
         let key = route.replace("{", with: "").replace("}", with: "")
         arguments[key] = path
 
+        matchCount += 1
         continue
       }
 
       if route != path {
         return nil
       }
+
+      matchCount += 1
     }
     
-    return (route: routeString, arguments: arguments)
+    return (route: routeString, arguments: arguments, matchCount: matchCount)
   }
 }
 


### PR DESCRIPTION
As a follow up with https://github.com/hyperoslo/Compass/pull/27

There are cases user has 2 routes that overlaps each other (one is a generic of the other)
This makes it explicit to select a route by considering the match count

```
"user:list",
"user:list:{userId}:{kind}",
```

I love the unit test 😄 
