### PR TITLE
Fix matching the route

### DIFF
--- a/Compass.xcodeproj/project.pbxproj
+++ b/Compass.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		BDF7B4111C3FF43F00576737 /* TestCompass.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF7B40F1C3FF43F00576737 /* TestCompass.swift */; };
 		BDF7B4151C3FF51100576737 /* Sugar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDF7B4141C3FF51100576737 /* Sugar.framework */; };
 		BDF7B4171C3FF51800576737 /* Sugar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDF7B4161C3FF51800576737 /* Sugar.framework */; };
+		D20D8C771D0708A800807EB1 /* Shuffle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20D8C761D0708A800807EB1 /* Shuffle.swift */; };
+		D20D8C781D0708A800807EB1 /* Shuffle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20D8C761D0708A800807EB1 /* Shuffle.swift */; };
 		D5A2A7931C4CEB1C00B51356 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7921C4CEB1C00B51356 /* Routable.swift */; };
 		D5A2A7971C4CEB7C00B51356 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2A7961C4CEB7C00B51356 /* Router.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Compass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Compass.framework */; };
@@ -47,6 +49,7 @@
 		BDF7B40F1C3FF43F00576737 /* TestCompass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCompass.swift; sourceTree = "<group>"; };
 		BDF7B4141C3FF51100576737 /* Sugar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sugar.framework; path = Carthage/Build/Mac/Sugar.framework; sourceTree = "<group>"; };
 		BDF7B4161C3FF51800576737 /* Sugar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sugar.framework; path = Carthage/Build/iOS/Sugar.framework; sourceTree = "<group>"; };
+		D20D8C761D0708A800807EB1 /* Shuffle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shuffle.swift; sourceTree = "<group>"; };
 		D5A2A7921C4CEB1C00B51356 /* Routable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
 		D5A2A7961C4CEB7C00B51356 /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Compass.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Compass.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -194,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				BDF7B40F1C3FF43F00576737 /* TestCompass.swift */,
+				D20D8C761D0708A800807EB1 /* Shuffle.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -417,6 +421,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BD93BC731C4D0CB5006D2D11 /* TestRouter.swift in Sources */,
+				D20D8C771D0708A800807EB1 /* Shuffle.swift in Sources */,
 				BDF7B4101C3FF43F00576737 /* TestCompass.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -435,6 +440,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDF7B4111C3FF43F00576737 /* TestCompass.swift in Sources */,
+				D20D8C781D0708A800807EB1 /* Shuffle.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CompassTests/Shared/Shuffle.swift
+++ b/CompassTests/Shared/Shuffle.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension CollectionType {
+  /// Return a copy of `self` with its elements shuffled
+  func shuffle() -> [Generator.Element] {
+    var list = Array(self)
+    list.shuffleInPlace()
+    return list
+  }
+}
+
+extension MutableCollectionType where Index == Int {
+  /// Shuffle the elements of `self` in-place.
+  mutating func shuffleInPlace() {
+    // empty and single-element collections don't shuffle
+    if count < 2 { return }
+
+    for i in 0..<count - 1 {
+      let j = Int(arc4random_uniform(UInt32(count - i))) + i
+      guard i != j else { continue }
+      (self[i], self[j]) = (self[j], self[i])
+      // instead of swap(&self[i], &self[j])
+    }
+  }
+}

--- a/CompassTests/Shared/TestCompass.swift
+++ b/CompassTests/Shared/TestCompass.swift
@@ -8,6 +8,7 @@ class TestCompass: XCTestCase {
     Compass.scheme = "compassTests"
     Compass.routes = [
       "profile:{user}",
+      "profile:admin",
       "login",
       "callback",
       "user:list:{userId}:{kind}",
@@ -22,7 +23,7 @@ class TestCompass: XCTestCase {
 
   func testRoutes() {
     XCTAssert(!Compass.routes.isEmpty)
-    XCTAssert(Compass.routes.count == 6)
+    XCTAssert(Compass.routes.count == 7)
   }
 
   func testParseArguments() {
@@ -47,6 +48,34 @@ class TestCompass: XCTestCase {
       XCTAssertEqual("profile:{user}", route)
       XCTAssertEqual(arguments["user"], "testUser")
       XCTAssertEqual("foo" , fragments["meta"] as? String)
+
+      expectation.fulfill()
+    }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
+  }
+
+  func testParseRouteConcreateMatchCount() {
+    let expectation = self.expectationWithDescription("Parse route having concrete match count")
+    let url = NSURL(string: "compassTests://profile:admin")!
+
+    Compass.parse(url) { route, arguments, _ in
+      XCTAssertEqual("profile:admin", route)
+      XCTAssert(arguments.isEmpty)
+
+      expectation.fulfill()
+    }
+
+    self.waitForExpectationsWithTimeout(4.0, handler:nil)
+  }
+
+  func testParseRouteWildcardMatchCount() {
+    let expectation = self.expectationWithDescription("Parse route having wildcard match count")
+    let url = NSURL(string: "compassTests://profile:jack")!
+
+    Compass.parse(url) { route, arguments, _ in
+      XCTAssertEqual("profile:{user}", route)
+      XCTAssertEqual(arguments["user"], "jack")
 
       expectation.fulfill()
     }
@@ -92,20 +121,6 @@ class TestCompass: XCTestCase {
       XCTAssertEqual(arguments["appId"], "12")
       XCTAssertEqual(arguments["userId"], "1")
       XCTAssertEqual(arguments["kind"], "admin")
-
-      expectation.fulfill()
-    }
-
-    self.waitForExpectationsWithTimeout(4.0, handler:nil)
-  }
-
-  func testParseOptionalArguments() {
-    let expectation = self.expectationWithDescription("Parse optional arguments")
-    let url = NSURL(string: "compassTests://profile")!
-
-    Compass.parse(url) { route, arguments, _ in
-      XCTAssertEqual("profile:{user}", route)
-      XCTAssert(arguments.isEmpty)
 
       expectation.fulfill()
     }

--- a/CompassTests/Shared/TestCompass.swift
+++ b/CompassTests/Shared/TestCompass.swift
@@ -10,10 +10,10 @@ class TestCompass: XCTestCase {
       "profile:{user}",
       "login",
       "callback",
-      "user:list",
       "user:list:{userId}:{kind}",
+      "user:list",
       "{appId}:user:list:{userId}:{kind}"
-    ]
+    ].shuffle()
   }
 
   func testScheme() {
@@ -23,8 +23,6 @@ class TestCompass: XCTestCase {
   func testRoutes() {
     XCTAssert(!Compass.routes.isEmpty)
     XCTAssert(Compass.routes.count == 6)
-    XCTAssertEqual(Compass.routes[0], "profile:{user}")
-    XCTAssertEqual(Compass.routes[1], "login")
   }
 
   func testParseArguments() {

--- a/Sources/Shared/Compass.swift
+++ b/Sources/Shared/Compass.swift
@@ -3,6 +3,8 @@ import Sugar
 
 public struct Compass {
 
+  typealias Result = (route: String, arguments: [String: String], matchCount: Int)
+
   private static var internalScheme = ""
 
   public static var delimiter: String = ":"
@@ -23,7 +25,7 @@ public struct Compass {
     guard !(path.containsString("?") || path.containsString("#"))
       else { return parseAsURL(url, completion: completion) }
 
-    let results = routes.flatMap {
+    let results: [Result] = routes.flatMap {
       return findMatch($0, pathString: path)
     }.sort {
       return $0.matchCount > $1.matchCount
@@ -55,7 +57,7 @@ public struct Compass {
   }
 
   static func findMatch(routeString: String, pathString: String)
-    -> (route: String, arguments: [String: String], matchCount: Int)? {
+    -> Result? {
 
     let routes = routeString.split(delimiter)
     let paths = pathString.split(delimiter)


### PR DESCRIPTION
- This add shuffle to the tests for route. So we're sure that order does not matter
- Remove optional route (aka components count does not match)

Example: we have 2 routes

```
a:b:{c}
a:b
```

and a urn `a:b`, then what route should we match?

Removing optional arguments makes it explicit to declare the route by always matching the number of components
- Check concrete and wildcard match count (aka components count matches, but we have overlap because of wildcard)

Example: we have 3 routes

```
a:b:c
a:b:{c}
a:{b}:{c}
```

and a urn `a:b:c`, then we should select route `a:b:c`

This is rare, actually
