### PR TITLE
Fixed query items parsing on the URL

### DIFF
--- a/Sources/Shared/Compass.swift
+++ b/Sources/Shared/Compass.swift
@@ -47,13 +47,12 @@ public struct Compass {
   static func parseAsURL(url: NSURL, completion: ParseCompletion) -> Bool {
     guard let route = url.host else { return false }
 
+    let urlComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)
+
     var arguments = [String : String]()
 
-    [url.fragment, url.query].forEach {
-      $0?.split("&").forEach {
-        let pair = $0.split("=")
-        arguments[pair[0]] = pair[1]
-      }
+    urlComponents?.queryItems?.forEach { queryItem in
+        arguments[queryItem.name] = queryItem.value
     }
 
     completion(route: route, arguments: arguments, fragments: [:])

--- a/Sources/Shared/Compass.swift
+++ b/Sources/Shared/Compass.swift
@@ -17,7 +17,7 @@ public struct Compass {
 
   public static var routes = [String]()
 
-  public typealias ParseCompletion = (route: String, arguments: [String : String], fragments : [String : AnyObject]) -> Void
+  public typealias ParseCompletion = (route: String, arguments: [String : String], fragments: [String : AnyObject]) -> Void
 
   public static func parse(url: NSURL, fragments: [String : AnyObject] = [:], completion: ParseCompletion) -> Bool {
 
@@ -55,6 +55,10 @@ public struct Compass {
         arguments[queryItem.name] = queryItem.value
     }
 
+    if let fragment = urlComponents?.fragment {
+        arguments = fragment.queryParameters()
+    }
+
     completion(route: route, arguments: arguments, fragments: [:])
 
     return true
@@ -87,9 +91,30 @@ public struct Compass {
         return nil
       }
     }
-    
+
     return (route: routeString, arguments: arguments,
             concreteMatchCount: concreteMatchCount, wildcardMatchCount: wildcardMatchCount)
   }
 }
 
+private extension String {
+
+    func queryParameters() -> [String: String] {
+        var parameters = [String: String]()
+
+        let separatorCharacters = NSCharacterSet(charactersInString: "&;")
+        self.componentsSeparatedByCharactersInSet(separatorCharacters).forEach { (pair) in
+
+            if let equalSeparator = pair.rangeOfString("=") {
+                let name = pair.substringToIndex(equalSeparator.startIndex)
+                let value = pair.substringFromIndex(equalSeparator.startIndex.advancedBy(1))
+                let cleaned = value.stringByRemovingPercentEncoding ?? value
+
+                parameters[name] = cleaned
+            }
+        }
+
+        return parameters
+    }
+
+}


### PR DESCRIPTION
I have discovered that splitting a URL query string in the form of `<scheme>:<host>/<path>?token=12Msdaqfcvee=` will result in `=` character being stripped out from the value. This is the default behaviour of `componentsSeparatedByString:` which is used by `split`

`NSURLComponents` will handle `=` character being part of the query item value. Because it parses character per character and it makes sure the names & values are valid.

Implementation details is here:
https://github.com/apple/swift-corelibs-foundation/blob/338f4bf3a89c75a0420b49f5701466e106af02b5/CoreFoundation/URL.subproj/CFURLComponents.c#L1017-L1172

Additionally, I added a method to parse the query parameters inside a URL fragment. Because, this is not supported by `NSURLComponents`.
