### PR TITLE
Feature: location payload

### DIFF
--- a/Sources/Compass.swift
+++ b/Sources/Compass.swift
@@ -36,7 +36,10 @@ public struct Compass {
     }
 
     if let result = results.first {
-      return Location(path: result.route, arguments: result.arguments, fragments: fragments, payload: payload)
+      return Location(path: result.route,
+                      arguments: result.arguments,
+                      fragments: fragments,
+                      payload: payload)
     }
 
     return nil
@@ -56,7 +59,10 @@ public struct Compass {
       arguments = fragment.queryParameters()
     }
 
-    return Location(path: route, arguments: arguments, fragments: fragments, payload: payload)
+    return Location(path: route,
+                    arguments: arguments,
+                    fragments: fragments,
+                    payload: payload)
   }
 
   static func findMatch(routeString: String, pathString: String) -> Result? {

--- a/Sources/Compass.swift
+++ b/Sources/Compass.swift
@@ -18,11 +18,11 @@ public struct Compass {
 
   public static var routes = [String]()
 
-  public static func parse(url: NSURL, fragments: [String : AnyObject] = [:], payload: Any? = nil) -> Location? {
+  public static func parse(url: NSURL, payload: Any? = nil) -> Location? {
     let path = url.absoluteString.substringFromIndex(scheme.endIndex)
 
     guard !(path.containsString("?") || path.containsString("#")) else {
-      return parseAsURL(url, fragments: fragments, payload: payload)
+      return parseAsURL(url, payload: payload)
     }
 
     let results: [Result] = routes.flatMap {
@@ -36,16 +36,13 @@ public struct Compass {
     }
 
     if let result = results.first {
-      return Location(path: result.route,
-                      arguments: result.arguments,
-                      fragments: fragments,
-                      payload: payload)
+      return Location(path: result.route, arguments: result.arguments, payload: payload)
     }
 
     return nil
   }
 
-  static func parseAsURL(url: NSURL, fragments: [String : AnyObject] = [:], payload: Any? = nil) -> Location? {
+  static func parseAsURL(url: NSURL, payload: Any? = nil) -> Location? {
     guard let route = url.host else { return nil }
 
     let urlComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)
@@ -59,10 +56,7 @@ public struct Compass {
       arguments = fragment.queryParameters()
     }
 
-    return Location(path: route,
-                    arguments: arguments,
-                    fragments: fragments,
-                    payload: payload)
+    return Location(path: route, arguments: arguments, payload: payload)
   }
 
   static func findMatch(routeString: String, pathString: String) -> Result? {

--- a/Sources/Compass.swift
+++ b/Sources/Compass.swift
@@ -18,11 +18,11 @@ public struct Compass {
 
   public static var routes = [String]()
 
-  public static func parse(url: NSURL, fragments: [String : AnyObject] = [:]) -> Location? {
+  public static func parse(url: NSURL, fragments: [String : AnyObject] = [:], payload: Any? = nil) -> Location? {
     let path = url.absoluteString.substringFromIndex(scheme.endIndex)
 
     guard !(path.containsString("?") || path.containsString("#")) else {
-      return parseAsURL(url, fragments: fragments)
+      return parseAsURL(url, fragments: fragments, payload: payload)
     }
 
     let results: [Result] = routes.flatMap {
@@ -36,13 +36,13 @@ public struct Compass {
     }
 
     if let result = results.first {
-      return Location(path: result.route, arguments: result.arguments, fragments: fragments)
+      return Location(path: result.route, arguments: result.arguments, fragments: fragments, payload: payload)
     }
 
     return nil
   }
 
-  static func parseAsURL(url: NSURL, fragments: [String : AnyObject] = [:]) -> Location? {
+  static func parseAsURL(url: NSURL, fragments: [String : AnyObject] = [:], payload: Any? = nil) -> Location? {
     guard let route = url.host else { return nil }
 
     let urlComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)
@@ -56,7 +56,7 @@ public struct Compass {
       arguments = fragment.queryParameters()
     }
 
-    return Location(path: route, arguments: arguments, fragments: fragments)
+    return Location(path: route, arguments: arguments, fragments: fragments, payload: payload)
   }
 
   static func findMatch(routeString: String, pathString: String) -> Result? {

--- a/Sources/Location.swift
+++ b/Sources/Location.swift
@@ -2,20 +2,15 @@ public struct Location {
 
   public let path: String
   public let arguments: [String: String]
-  public let fragments: [String: AnyObject]
   public let payload: Any?
 
   public var scheme: String {
     return Compass.scheme
   }
 
-  public init(path: String,
-              arguments: [String: String] = [:],
-              fragments: [String: AnyObject] = [:],
-              payload: Any? = nil) {
+  public init(path: String, arguments: [String: String] = [:], payload: Any? = nil) {
     self.path = path
     self.arguments = arguments
-    self.fragments = fragments
     self.payload = payload
   }
 }

--- a/Sources/Location.swift
+++ b/Sources/Location.swift
@@ -3,14 +3,19 @@ public struct Location {
   public let path: String
   public let arguments: [String: String]
   public let fragments: [String: AnyObject]
+  public let payload: Any?
 
   public var scheme: String {
     return Compass.scheme
   }
 
-  public init(path: String, arguments: [String: String] = [:], fragments: [String: AnyObject] = [:]) {
+  public init(path: String,
+              arguments: [String: String] = [:],
+              fragments: [String: AnyObject] = [:],
+              payload: Any? = nil) {
     self.path = path
     self.arguments = arguments
     self.fragments = fragments
+    self.payload = payload
   }
 }

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -1,3 +1,9 @@
+public enum RouteError: ErrorType {
+  case NotFound
+  case InvalidArguments(Location)
+  case InvalidPayload(Location)
+}
+
 public protocol Routable {
 
   func navigate(to location: Location, from currentController: Controller) throws
@@ -6,10 +12,6 @@ public protocol Routable {
 public protocol ErrorRoutable {
 
   func handle(routeError: ErrorType, from currentController: Controller)
-}
-
-public enum RouteError: ErrorType {
-  case NotFound
 }
 
 public struct Router: Routable {

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -1,16 +1,34 @@
 public protocol Routable {
 
-  func navigate(to location: Location, from currentController: Controller)
+  func navigate(to location: Location, from currentController: Controller) throws
+}
+
+public protocol ErrorRoutable {
+
+  func handle(routeError: ErrorType, from currentController: Controller)
+}
+
+public enum RouteError: ErrorType {
+  case NotFound
 }
 
 public struct Router: Routable {
 
   public var routes = [String: Routable]()
+  public var errorRoute: ErrorRoutable?
 
   public init() {}
 
   public func navigate(to location: Location, from currentController: Controller) {
-    guard let route = routes[location.path] else { return }
-    route.navigate(to: location, from: currentController)
+    guard let route = routes[location.path] else {
+      errorRoute?.handle(RouteError.NotFound, from: currentController)
+      return
+    }
+
+    do {
+      try route.navigate(to: location, from: currentController)
+    } catch {
+      errorRoute?.handle(error, from: currentController)
+    }
   }
 }

--- a/Tests/Compass/CompassTests.swift
+++ b/Tests/Compass/CompassTests.swift
@@ -51,6 +51,22 @@ class CompassTests: XCTestCase {
     XCTAssertEqual("foo" , location.fragments["meta"] as? String)
   }
 
+  func testParsePayload() {
+    let url = NSURL(string: "compassTests://profile:testUser")!
+
+    typealias Payload = (firstName: String, lastName: String)
+
+    guard let location = Compass.parse(url, payload: Payload(firstName: "foo", lastName: "bar")) else {
+      XCTFail("Compass parsing failed")
+      return
+    }
+
+    XCTAssertEqual("profile:{user}", location.path)
+    XCTAssertEqual(location.arguments["user"], "testUser")
+    XCTAssertEqual("foo" , (location.payload as? Payload)?.firstName)
+    XCTAssertEqual("bar" , (location.payload as? Payload)?.lastName)
+  }
+
   func testParseRouteConcreateMatchCount() {
     let url = NSURL(string: "compassTests://profile:admin")!
 

--- a/Tests/Compass/CompassTests.swift
+++ b/Tests/Compass/CompassTests.swift
@@ -38,19 +38,6 @@ class CompassTests: XCTestCase {
     XCTAssertEqual(location.arguments["user"], "testUser")
   }
 
-  func testParseFragments() {
-    let url = NSURL(string: "compassTests://profile:testUser")!
-
-    guard let location = Compass.parse(url, fragments: ["meta" : "foo"]) else {
-      XCTFail("Compass parsing failed")
-      return
-    }
-
-    XCTAssertEqual("profile:{user}", location.path)
-    XCTAssertEqual(location.arguments["user"], "testUser")
-    XCTAssertEqual("foo" , location.fragments["meta"] as? String)
-  }
-
   func testParsePayload() {
     let url = NSURL(string: "compassTests://profile:testUser")!
 

--- a/Tests/Compass/Helpers.swift
+++ b/Tests/Compass/Helpers.swift
@@ -14,8 +14,12 @@ class TestRoute: Routable {
 
 class ThrowableRoute: Routable {
 
+  enum Error: ErrorType {
+    case Unknown
+  }
+
   func navigate(to location: Location, from currentController: Controller) throws {
-    throw RouteError.NotFound
+    throw Error.Unknown
   }
 }
 

--- a/Tests/Compass/Helpers.swift
+++ b/Tests/Compass/Helpers.swift
@@ -7,8 +7,24 @@ class TestRoute: Routable {
 
   var resolved = false
 
-  func navigate(to location: Location, from currentController: Controller) {
+  func navigate(to location: Location, from currentController: Controller) throws {
     resolved = true
+  }
+}
+
+class ThrowableRoute: Routable {
+
+  func navigate(to location: Location, from currentController: Controller) throws {
+    throw RouteError.NotFound
+  }
+}
+
+class ErrorRoute: ErrorRoutable {
+
+  var error: ErrorType?
+
+  func handle(routeError: ErrorType, from currentController: Controller) {
+    error = routeError
   }
 }
 

--- a/Tests/Compass/RouterTests.swift
+++ b/Tests/Compass/RouterTests.swift
@@ -5,12 +5,13 @@ import XCTest
 class RouterTests: XCTestCase {
 
   var router: Router!
-  var controller = Controller()
   var route: TestRoute!
+  var controller: Controller!
 
   override func setUp() {
     router = Router()
     route = TestRoute()
+    controller = Controller()
   }
 
   func testNavigateIfRouteRegistered() {

--- a/Tests/Compass/RouterTests.swift
+++ b/Tests/Compass/RouterTests.swift
@@ -32,4 +32,11 @@ class RouterTests: XCTestCase {
     XCTAssertFalse(route.resolved)
     XCTAssertTrue(errorRoute.error is RouteError)
   }
+
+  func testNavigateIfRouteThrowsError() {
+    router.routes["throw"] = ThrowableRoute()
+    router.navigate(to: Location(path: "throw"), from: controller)
+
+    XCTAssertTrue(errorRoute.error is ThrowableRoute.Error)
+  }
 }

--- a/Tests/Compass/RouterTests.swift
+++ b/Tests/Compass/RouterTests.swift
@@ -7,11 +7,15 @@ class RouterTests: XCTestCase {
   var router: Router!
   var route: TestRoute!
   var controller: Controller!
+  var errorRoute: ErrorRoute!
 
   override func setUp() {
     router = Router()
     route = TestRoute()
     controller = Controller()
+    errorRoute = ErrorRoute()
+
+    router.errorRoute = errorRoute
   }
 
   func testNavigateIfRouteRegistered() {
@@ -19,11 +23,13 @@ class RouterTests: XCTestCase {
     router.navigate(to: Location(path: "test"), from: controller)
 
     XCTAssertTrue(route.resolved)
+    XCTAssertNil(errorRoute.error)
   }
 
   func testNavigateIfRouteNotRegistered() {
     router.navigate(to: Location(path: "test"), from: controller)
 
     XCTAssertFalse(route.resolved)
+    XCTAssertTrue(errorRoute.error is RouteError)
   }
 }


### PR DESCRIPTION
@zenangst @onmyway133 @RamonGilabert 

1) We had some discussions about type-safety and magic strings in fragments. We can't really use generics just for optional function parameters. And if we conform to `Mappable` like in https://github.com/hyperoslo/Brick/pull/12 it adds `Tailor` as a dependency and could lead to many small struct types in the project codebase. My solution here is to add a new property on `Location`:

``` swift
public let payload: Any?
```

Since it's `Any` we can pass whatever we want and then cast it to the type that we expect:

``` swift
struct User {
  let firstName: String
  let lastName: String
}

let user = User(firstName: "foo", lastName: "bar")

guard let location = Compass.parse(url, payload: user) else {
  return
}

// ...

if let user = location.payload as? User {
  print("\(user.firstName) \(user.lastName)")
}
```

2) If you like new `payload` property, do we need `fragments` at all? Because you can set `[String: AnyObject]` dictionary as payload. The only disadvantage is that you have to cast it later:

``` swift
guard let location = Compass.parse(url, payload: ["foo": "bar"]) else {
  return
}

// ...

if let payload = location.payload as? [String: String] {
  print(payload["foo"])
}

What do you think?
```

3) From now we can throw errors in `Routable` that will be caught in `Router` and handled by a new type called `ErrorRoutable`. It means we can present some error screen when the route is not found or arguments are invalid.

``` swift
class ErrorRoute: ErrorRoutable {
  var error: ErrorType?

  func handle(routeError: ErrorType, from currentController: Controller) {
    error = routeError
  }
}

class ThrowableRoute: Routable {
  func navigate(to location: Location, from currentController: Controller) throws {
    throw RouteError.InvalidArguments(location)
  }
}

let router = Router()
let errorRoute = ErrorRoute()

router.errorRoute = errorRoute // errorRoute is an optional var
router.routes["throw"] = ThrowableRoute()
router.navigate(to: Location(path: "throw"), from: UIViewController())

print(errorRoute.error) // RouteError.InvalidArguments

```
