### PR TITLE
Support regular urls that have a path component

### DIFF
--- a/Sources/Compass.swift
+++ b/Sources/Compass.swift
@@ -43,7 +43,8 @@ public struct Compass {
   }
 
   static func parseComponents(url: URL, payload: Any? = nil) -> Location? {
-    guard let route = url.host else { return nil }
+    guard let host = url.host else { return nil }
+    let route = "\(host)\(url.path)"
 
     let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
     var arguments = [String : String]()

--- a/Tests/Compass/CompassTests.swift
+++ b/Tests/Compass/CompassTests.swift
@@ -10,7 +10,7 @@ class CompassTests: XCTestCase {
       "profile:{user}",
       "profile:admin",
       "login",
-      "callback",
+      "callback/path",
       "user:list:{userId}:{kind}",
       "user:list",
       "{appId}:user:list:{userId}:{kind}"
@@ -130,14 +130,14 @@ class CompassTests: XCTestCase {
   }
 
   func testParseRegularURLWithFragments() {
-    let url = URL(string: "compassTests://callback/#access_token=IjvcgrkQk1p7TyJxKa26rzM1wBMFZW6XoHK4t5Gkt1xQLTN8l7ppR0H3EZXpoP0uLAN49oCDqTHsvnEV&token_type=Bearer&expires_in=3600")!
+    let url = URL(string: "compassTests://callback/path/#access_token=IjvcgrkQk1p7TyJxKa26rzM1wBMFZW6XoHK4t5Gkt1xQLTN8l7ppR0H3EZXpoP0uLAN49oCDqTHsvnEV&token_type=Bearer&expires_in=3600")!
 
     guard let location = Compass.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
 
-    XCTAssertEqual(location.path, "callback")
+    XCTAssertEqual(location.path, "callback/path")
     XCTAssertEqual(location.arguments.count, 3)
     XCTAssertEqual(location.arguments["access_token"], "IjvcgrkQk1p7TyJxKa26rzM1wBMFZW6XoHK4t5Gkt1xQLTN8l7ppR0H3EZXpoP0uLAN49oCDqTHsvnEV")
     XCTAssertEqual(location.arguments["expires_in"], "3600")
@@ -145,14 +145,14 @@ class CompassTests: XCTestCase {
   }
 
   func testParseRegularURLWithFragmentsAndGoogleOAuth2AccessToken() {
-    let url = URL(string: "compassTests://callback/#access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ&token_type=Bearer&expires_in=3600")!
+    let url = URL(string: "compassTests://callback/path/#access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ&token_type=Bearer&expires_in=3600")!
 
     guard let location = Compass.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
 
-    XCTAssertEqual(location.path, "callback")
+    XCTAssertEqual(location.path, "callback/path")
     XCTAssertEqual(location.arguments.count, 3)
     XCTAssertEqual(location.arguments["access_token"], "ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ")
     XCTAssertEqual(location.arguments["expires_in"], "3600")
@@ -160,14 +160,14 @@ class CompassTests: XCTestCase {
   }
 
   func testParseRegularURLWithFragmentsAndAlternativeAccessToken() {
-    let url = URL(string: "compassTests://callback/#access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=&token_type=Bearer&expires_in=3600")!
+    let url = URL(string: "compassTests://callback/path/#access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=&token_type=Bearer&expires_in=3600")!
 
     guard let location = Compass.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
 
-    XCTAssertEqual(location.path, "callback")
+    XCTAssertEqual(location.path, "callback/path")
     XCTAssertEqual(location.arguments.count, 3)
     XCTAssertEqual(location.arguments["access_token"], "ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=")
     XCTAssertEqual(location.arguments["expires_in"], "3600")
@@ -175,14 +175,14 @@ class CompassTests: XCTestCase {
   }
 
   func testParseRegularURLWithSlashQuery() {
-    let url = URL(string: "compassTests://callback/?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
+    let url = URL(string: "compassTests://callback/path/?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
 
     guard let location = Compass.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
 
-    XCTAssertEqual(location.path, "callback")
+    XCTAssertEqual(location.path, "callback/path")
     XCTAssertEqual(location.arguments.count, 3)
     XCTAssertEqual(location.arguments["access_token"], "Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l")
     XCTAssertEqual(location.arguments["expires_in"], "3600")
@@ -190,14 +190,14 @@ class CompassTests: XCTestCase {
   }
 
   func testParseRegularURLWithSlashQueryAndGoogleOAuth2AccessToken() {
-    let url = URL(string: "compassTests://callback/?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ&token_type=Bearer&expires_in=3600")!
+    let url = URL(string: "compassTests://callback/path/?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ&token_type=Bearer&expires_in=3600")!
 
     guard let location = Compass.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
 
-    XCTAssertEqual(location.path, "callback")
+    XCTAssertEqual(location.path, "callback/path")
     XCTAssertEqual(location.arguments.count, 3)
     XCTAssertEqual(location.arguments["access_token"], "ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ")
     XCTAssertEqual(location.arguments["expires_in"], "3600")
@@ -205,14 +205,14 @@ class CompassTests: XCTestCase {
   }
 
   func testParseRegularURLWithSlashQueryAndAlternativeAccessToken() {
-    let url = URL(string: "compassTests://callback/?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=&token_type=Bearer&expires_in=3600")!
+    let url = URL(string: "compassTests://callback/path/?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=&token_type=Bearer&expires_in=3600")!
 
     guard let location = Compass.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
 
-    XCTAssertEqual(location.path, "callback")
+    XCTAssertEqual(location.path, "callback/path")
     XCTAssertEqual(location.arguments.count, 3)
     XCTAssertEqual(location.arguments["access_token"], "ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=")
     XCTAssertEqual(location.arguments["expires_in"], "3600")
@@ -220,14 +220,14 @@ class CompassTests: XCTestCase {
   }
 
   func testParseRegularURLWithQuery() {
-    let url = URL(string: "compassTests://callback?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
+    let url = URL(string: "compassTests://callback/path?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
 
     guard let location = Compass.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
 
-    XCTAssertEqual(location.path, "callback")
+    XCTAssertEqual(location.path, "callback/path")
     XCTAssertEqual(location.arguments.count, 3)
     XCTAssertEqual(location.arguments["access_token"], "Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l")
     XCTAssertEqual(location.arguments["expires_in"], "3600")
@@ -235,14 +235,14 @@ class CompassTests: XCTestCase {
   }
 
   func testParseRegularURLWithQueryAndGoogleOAuth2AccessToken() {
-    let url = URL(string: "compassTests://callback?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ&token_type=Bearer&expires_in=3600")!
+    let url = URL(string: "compassTests://callback/path?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ&token_type=Bearer&expires_in=3600")!
 
     guard let location = Compass.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
 
-    XCTAssertEqual(location.path, "callback")
+    XCTAssertEqual(location.path, "callback/path")
     XCTAssertEqual(location.arguments.count, 3)
     XCTAssertEqual(location.arguments["access_token"], "ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ")
     XCTAssertEqual(location.arguments["expires_in"], "3600")
@@ -250,14 +250,14 @@ class CompassTests: XCTestCase {
   }
 
   func testParseRegularURLWithQueryAndAlternativeAccessToken() {
-    let url = URL(string: "compassTests://callback?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=&token_type=Bearer&expires_in=3600")!
+    let url = URL(string: "compassTests://callback/path?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=&token_type=Bearer&expires_in=3600")!
 
     guard let location = Compass.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
 
-    XCTAssertEqual(location.path, "callback")
+    XCTAssertEqual(location.path, "callback/path")
     XCTAssertEqual(location.arguments.count, 3)
     XCTAssertEqual(location.arguments["access_token"], "ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=")
     XCTAssertEqual(location.arguments["expires_in"], "3600")


### PR DESCRIPTION
Constructs the `Location.path` based on the `URL.host` + `URL.path`, so that URLs such as `scheme://callback/path` are supported.