### PR TITLE
Rename struct Compass to Navigator

### DIFF
--- a/Compass.xcodeproj/project.pbxproj
+++ b/Compass.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		D5361FF91D6C7133003C3EE8 /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF11D6C7133003C3EE8 /* TypeAlias.swift */; };
 		D5361FFA1D6C7133003C3EE8 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF21D6C7133003C3EE8 /* String+Extensions.swift */; };
 		D5361FFB1D6C7133003C3EE8 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF21D6C7133003C3EE8 /* String+Extensions.swift */; };
-		D5361FFC1D6C7133003C3EE8 /* Compass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF31D6C7133003C3EE8 /* Compass.swift */; };
-		D5361FFD1D6C7133003C3EE8 /* Compass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF31D6C7133003C3EE8 /* Compass.swift */; };
+		D5361FFC1D6C7133003C3EE8 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF31D6C7133003C3EE8 /* Navigator.swift */; };
+		D5361FFD1D6C7133003C3EE8 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF31D6C7133003C3EE8 /* Navigator.swift */; };
 		D53620251D6C749A003C3EE8 /* CompassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D536200F1D6C743A003C3EE8 /* CompassTests.swift */; };
 		D53620261D6C749A003C3EE8 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53620101D6C743A003C3EE8 /* Helpers.swift */; };
 		D53620271D6C749A003C3EE8 /* RouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53620111D6C743A003C3EE8 /* RouterTests.swift */; };
@@ -25,7 +25,7 @@
 		D536202D1D6C8532003C3EE8 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = D536202B1D6C8532003C3EE8 /* Location.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Compass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Compass.framework */; };
 		D5C6294A1C3A7FAA007F7B7C /* Compass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Compass.framework */; };
-		FDD723361DCA20BC00D722E4 /* Compass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF31D6C7133003C3EE8 /* Compass.swift */; };
+		FDD723361DCA20BC00D722E4 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF31D6C7133003C3EE8 /* Navigator.swift */; };
 		FDD723371DCA20BC00D722E4 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF21D6C7133003C3EE8 /* String+Extensions.swift */; };
 		FDD723381DCA20BC00D722E4 /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FF11D6C7133003C3EE8 /* TypeAlias.swift */; };
 		FDD723391DCA20BC00D722E4 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5361FEF1D6C7133003C3EE8 /* Router.swift */; };
@@ -53,7 +53,7 @@
 		D5361FEF1D6C7133003C3EE8 /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		D5361FF11D6C7133003C3EE8 /* TypeAlias.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		D5361FF21D6C7133003C3EE8 /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
-		D5361FF31D6C7133003C3EE8 /* Compass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Compass.swift; sourceTree = "<group>"; };
+		D5361FF31D6C7133003C3EE8 /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		D536200F1D6C743A003C3EE8 /* CompassTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompassTests.swift; sourceTree = "<group>"; };
 		D53620101D6C743A003C3EE8 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		D53620111D6C743A003C3EE8 /* RouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouterTests.swift; sourceTree = "<group>"; };
@@ -169,7 +169,7 @@
 				D5361FEF1D6C7133003C3EE8 /* Router.swift */,
 				D5361FF11D6C7133003C3EE8 /* TypeAlias.swift */,
 				D5361FF21D6C7133003C3EE8 /* String+Extensions.swift */,
-				D5361FF31D6C7133003C3EE8 /* Compass.swift */,
+				D5361FF31D6C7133003C3EE8 /* Navigator.swift */,
 				D536202B1D6C8532003C3EE8 /* Location.swift */,
 			);
 			path = Sources;
@@ -299,7 +299,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = "Hyper Interaktiv AS";
 				TargetAttributes = {
 					D5B2E89E1C3A780C00C0327D = {
@@ -382,7 +382,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5361FFC1D6C7133003C3EE8 /* Compass.swift in Sources */,
+				D5361FFC1D6C7133003C3EE8 /* Navigator.swift in Sources */,
 				D5361FFA1D6C7133003C3EE8 /* String+Extensions.swift in Sources */,
 				D5361FF81D6C7133003C3EE8 /* TypeAlias.swift in Sources */,
 				D5361FF41D6C7133003C3EE8 /* Router.swift in Sources */,
@@ -404,7 +404,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5361FFD1D6C7133003C3EE8 /* Compass.swift in Sources */,
+				D5361FFD1D6C7133003C3EE8 /* Navigator.swift in Sources */,
 				D5361FFB1D6C7133003C3EE8 /* String+Extensions.swift in Sources */,
 				D5361FF91D6C7133003C3EE8 /* TypeAlias.swift in Sources */,
 				D5361FF51D6C7133003C3EE8 /* Router.swift in Sources */,
@@ -426,7 +426,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FDD723361DCA20BC00D722E4 /* Compass.swift in Sources */,
+				FDD723361DCA20BC00D722E4 /* Navigator.swift in Sources */,
 				FDD723371DCA20BC00D722E4 /* String+Extensions.swift in Sources */,
 				FDD723381DCA20BC00D722E4 /* TypeAlias.swift in Sources */,
 				FDD723391DCA20BC00D722E4 /* Router.swift in Sources */,
@@ -463,8 +463,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -512,8 +514,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -534,6 +538,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -545,6 +550,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -566,6 +572,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -694,6 +701,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -717,6 +725,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/Compass.xcodeproj/xcshareddata/xcschemes/Compass-Mac.xcscheme
+++ b/Compass.xcodeproj/xcshareddata/xcschemes/Compass-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Compass.xcodeproj/xcshareddata/xcschemes/Compass-iOS.xcscheme
+++ b/Compass.xcodeproj/xcshareddata/xcschemes/Compass-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Compass.xcodeproj/xcshareddata/xcschemes/Compass-tvOS.xcscheme
+++ b/Compass.xcodeproj/xcshareddata/xcschemes/Compass-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Location.swift
+++ b/Sources/Location.swift
@@ -5,7 +5,7 @@ public struct Location {
   public let payload: Any?
 
   public var scheme: String {
-    return Compass.scheme
+    return Navigator.scheme
   }
 
   public init(path: String, arguments: [String: String] = [:], payload: Any? = nil) {

--- a/Sources/Navigator.swift
+++ b/Sources/Navigator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Compass {
+public struct Navigator {
 
   typealias Result = (
     route: String,
@@ -12,8 +12,8 @@ public struct Compass {
   public static var delimiter: String = ":"
 
   public static var scheme: String {
-    set { Compass.internalScheme = newValue }
-    get { return "\(Compass.internalScheme)://" }
+    set { Navigator.internalScheme = newValue }
+    get { return "\(Navigator.internalScheme)://" }
   }
 
   public static var routes = [String]()
@@ -93,13 +93,13 @@ public struct Compass {
   }
 }
 
-extension Compass {
+extension Navigator {
 
-  public static func compassURL(urn: String, scheme: String = Compass.scheme) -> URL? {
+  public static func compassURL(urn: String, scheme: String = Navigator.scheme) -> URL? {
     return URL(string: "\(scheme)\(urn.compass_encoded())")
   }
 
-  public static func navigate(to urn: String, scheme: String = Compass.scheme) {
+  public static func navigate(to urn: String, scheme: String = Navigator.scheme) {
     guard let url = compassURL(urn: urn, scheme: scheme) else { return }
     open(url: url)
   }

--- a/Tests/Compass/CompassTests.swift
+++ b/Tests/Compass/CompassTests.swift
@@ -5,8 +5,8 @@ import Compass
 class CompassTests: XCTestCase {
 
   override func setUp() {
-    Compass.scheme = "compassTests"
-    Compass.routes = [
+    Navigator.scheme = "compassTests"
+    Navigator.routes = [
       "profile:{user}",
       "profile:admin",
       "login",
@@ -19,18 +19,18 @@ class CompassTests: XCTestCase {
   }
 
   func testScheme() {
-    XCTAssertEqual(Compass.scheme, "compassTests://")
+    XCTAssertEqual(Navigator.scheme, "compassTests://")
   }
 
   func testRoutes() {
-    XCTAssert(!Compass.routes.isEmpty)
-    XCTAssert(Compass.routes.count == 8)
+    XCTAssert(!Navigator.routes.isEmpty)
+    XCTAssert(Navigator.routes.count == 8)
   }
 
   func testParseArguments() {
     let url = URL(string: "compassTests://profile:testUser")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -44,7 +44,7 @@ class CompassTests: XCTestCase {
 
     typealias Payload = (firstName: String, lastName: String)
 
-    guard let location = Compass.parse(url: url, payload: Payload(firstName: "foo", lastName: "bar")) else {
+    guard let location = Navigator.parse(url: url, payload: Payload(firstName: "foo", lastName: "bar")) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -58,7 +58,7 @@ class CompassTests: XCTestCase {
   func testParseRouteConcreateMatchCount() {
     let url = URL(string: "compassTests://profile:admin")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -70,7 +70,7 @@ class CompassTests: XCTestCase {
   func testParseRouteWildcardMatchCount() {
     let url = URL(string: "compassTests://profile:jack")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -82,7 +82,7 @@ class CompassTests: XCTestCase {
   func testParseRouteSamePrefix() {
     let url = URL(string: "compassTests://user:list")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -94,7 +94,7 @@ class CompassTests: XCTestCase {
   func testParseMultipleArguments() {
     let url = URL(string: "compassTests://user:list:1:admin")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -107,7 +107,7 @@ class CompassTests: XCTestCase {
   func testParseMultipleArgumentsWithFirstWildcard() {
     let url = URL(string: "compassTests://12:user:list:1:admin")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -121,7 +121,7 @@ class CompassTests: XCTestCase {
   func testParseWithoutArguments() {
     let url = URL(string: "compassTests://login")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -133,7 +133,7 @@ class CompassTests: XCTestCase {
   func testParseRegularURLWithFragments() {
     let url = URL(string: "compassTests://callback/#access_token=IjvcgrkQk1p7TyJxKa26rzM1wBMFZW6XoHK4t5Gkt1xQLTN8l7ppR0H3EZXpoP0uLAN49oCDqTHsvnEV&token_type=Bearer&expires_in=3600")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -148,7 +148,7 @@ class CompassTests: XCTestCase {
   func testParseRegularURLWithFragmentsAndGoogleOAuth2AccessToken() {
     let url = URL(string: "compassTests://callback/#access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ&token_type=Bearer&expires_in=3600")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -163,7 +163,7 @@ class CompassTests: XCTestCase {
   func testParseRegularURLWithFragmentsAndAlternativeAccessToken() {
     let url = URL(string: "compassTests://callback/#access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=&token_type=Bearer&expires_in=3600")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -178,7 +178,7 @@ class CompassTests: XCTestCase {
   func testParseRegularURLWithSlashQuery() {
     let url = URL(string: "compassTests://callback/?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -193,7 +193,7 @@ class CompassTests: XCTestCase {
   func testParseRegularURLWithSlashQueryAndGoogleOAuth2AccessToken() {
     let url = URL(string: "compassTests://callback/?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ&token_type=Bearer&expires_in=3600")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -208,7 +208,7 @@ class CompassTests: XCTestCase {
   func testParseRegularURLWithSlashQueryAndAlternativeAccessToken() {
     let url = URL(string: "compassTests://callback/?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=&token_type=Bearer&expires_in=3600")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -223,7 +223,7 @@ class CompassTests: XCTestCase {
   func testParseRegularURLWithQuery() {
     let url = URL(string: "compassTests://callback?access_token=Yo0OMrVZbRWNmgA6BT99hyuTUTNRGvqEEAQyeN1eslclzhFD0M8AidB4Z7Vs2NU8WoSNW0vYb961O38l&token_type=Bearer&expires_in=3600")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -238,7 +238,7 @@ class CompassTests: XCTestCase {
   func testParseRegularURLWithQueryAndGoogleOAuth2AccessToken() {
     let url = URL(string: "compassTests://callback?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ&token_type=Bearer&expires_in=3600")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -253,7 +253,7 @@ class CompassTests: XCTestCase {
   func testParseRegularURLWithQueryAndAlternativeAccessToken() {
     let url = URL(string: "compassTests://callback?access_token=ya29.Ci8nA1pNVMFffHkS5-sXooNGvTB9q8QPtoM56sWpipRyjhwwEiKyZxvRQTR8saqWzQ=&token_type=Bearer&expires_in=3600")!
 
-    guard let location = Compass.parse(url: url) else {
+    guard let location = Navigator.parse(url: url) else {
       XCTFail("Compass parsing failed")
       return
     }
@@ -267,11 +267,11 @@ class CompassTests: XCTestCase {
 
   func testEncodedURN() {
     let urn = "organization:hyper oslo:simply awesome"
-    let url = Compass.compassURL(urn: urn)
+    let url = Navigator.compassURL(urn: urn)
 
     XCTAssertNotNil(url)
 
-    guard let location = Compass.parse(url: url!) else {
+    guard let location = Navigator.parse(url: url!) else {
       XCTFail("Compass parsing failed")
       return
     }


### PR DESCRIPTION
⚠️ Breaking change ⚠️ 

As of https://github.com/hyperoslo/Compass/issues/44
This renames struct `Compass` to `Navigator`, in order for the framework namespace `Compass` to work