### PR TITLE
Fix navigator

### DIFF
--- a/Sources/Location.swift
+++ b/Sources/Location.swift
@@ -11,11 +11,6 @@ public struct Location {
   /// An optional payload if you want to send in app objects
   public let payload: Any?
 
-  /// The application scheme
-  public var scheme: String {
-    return Navigator.scheme
-  }
-
   /// Construct a Location
   public init(path: String, arguments: [String: String] = [:], payload: Any? = nil) {
     self.path = path

--- a/Sources/Navigator.swift
+++ b/Sources/Navigator.swift
@@ -2,14 +2,6 @@ import Foundation
 
 /// The Navigator is used to parse Location from url, and navigate
 public struct Navigator {
-
-  /// The Result used in the findMatch function
-  typealias Result = (
-    route: String,
-    arguments: [String: String],
-    concreteMatchCount: Int,
-    wildcardMatchCount: Int)
-
   fileprivate static var internalScheme = ""
 
   /// The delimiter used to split parts within url, default to :
@@ -73,7 +65,7 @@ public struct Navigator {
   ///   - url: The url to be parsed
   ///   - payload: The optional payload if you want to send in app objects
   /// - Returns: The Location that can be used
-  static func parseComponents(url: URL, payload: Any? = nil) -> Location? {
+  fileprivate static func parseComponents(url: URL, payload: Any? = nil) -> Location? {
     guard let route = url.host else { return nil }
 
     let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
@@ -90,13 +82,20 @@ public struct Navigator {
     return Location(path: route, arguments: arguments, payload: payload)
   }
 
+  /// The Result used in the findMatch function
+  fileprivate typealias Result = (
+    route: String,
+    arguments: [String: String],
+    concreteMatchCount: Int,
+    wildcardMatchCount: Int)
+
   /// Find the best match registed route for a certain route string
   ///
   /// - Parameters:
   ///   - routeString: The registered route string
   ///   - pathString: The path extracted from the requested url
   /// - Returns: The Result on how this pathString matches
-  static func findMatch(routeString: String, pathString: String) -> Result? {
+  fileprivate static func findMatch(routeString: String, pathString: String) -> Result? {
     let routes = routeString.split(delimiter)
     let paths = pathString.split(delimiter)
 

--- a/Sources/Navigator.swift
+++ b/Sources/Navigator.swift
@@ -24,6 +24,18 @@ public struct Navigator {
   /// A list of route strings
   public static var routes = [String]()
 
+  /// Parse Location from urn
+  ///
+  /// - Parameter urn: Safely construct url from urn, perform percent encoding
+  /// - Returns: The Location that can be used
+  public static func parse(urn: String) -> Location? {
+    guard let url =  URL(string: "\(scheme)\(urn.compass_encoded())") else {
+      return nil
+    }
+
+    return parse(url: url)
+  }
+
   /// Parse Location from url
   ///
   /// - Parameters:
@@ -115,29 +127,5 @@ public struct Navigator {
             arguments: arguments,
             concreteMatchCount: concreteMatchCount,
             wildcardMatchCount: wildcardMatchCount)
-  }
-}
-
-extension Navigator {
-
-  /// Parse an urn to be Compass friendly URL
-  ///
-  /// - Parameters:
-  ///   - urn: The requested urn
-  ///   - scheme: The application scheme
-  /// - Returns: The URL to be ready used by Compass
-  public static func compassURL(urn: String, scheme: String = Navigator.scheme) -> URL? {
-    return URL(string: "\(scheme)\(urn.compass_encoded())")
-  }
-
-
-  /// Navigate by telling the application to open a url
-  ///
-  /// - Parameters:
-  ///   - urn: The requested urn
-  ///   - scheme: The application scheme
-  public static func navigate(to urn: String, scheme: String = Navigator.scheme) {
-    guard let url = compassURL(urn: urn, scheme: scheme) else { return }
-    open(url: url)
   }
 }

--- a/Tests/Compass/CompassTests.swift
+++ b/Tests/Compass/CompassTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import Compass
+@testable import Compass
 
 class CompassTests: XCTestCase {
 
@@ -267,11 +267,8 @@ class CompassTests: XCTestCase {
 
   func testEncodedURN() {
     let urn = "organization:hyper oslo:simply awesome"
-    let url = Navigator.compassURL(urn: urn)
 
-    XCTAssertNotNil(url)
-
-    guard let location = Navigator.parse(url: url!) else {
+    guard let location = Navigator.parse(urn: urn) else {
       XCTFail("Compass parsing failed")
       return
     }

--- a/Tests/Compass/CompassTests.swift
+++ b/Tests/Compass/CompassTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import Compass
+import Compass
 
 class CompassTests: XCTestCase {
 


### PR DESCRIPTION
- Add `parse(urn)` on `Navigator`. It performs `percent encoding` and call `parse(url)` to get `Location`
- Remove unused properties and methods
- Mark helper methods are `fileprivate`